### PR TITLE
bug fix for "STRING_TOO_LONG, Full Mail Body: data value too large"

### DIFF
--- a/force-app/main/default/classes/ErrorMailReceiver.cls
+++ b/force-app/main/default/classes/ErrorMailReceiver.cls
@@ -1,7 +1,7 @@
 global with sharing class ErrorMailReceiver implements Messaging.InboundEmailHandler {
 
     global Messaging.InboundEmailResult handleInboundEmail(Messaging.InboundEmail mail, Messaging.InboundEnvelope envelope) {
-        insert as system new OrgError__c(txl_FullMailBody__c = mail.plainTextBody);
+        insert as system new OrgError__c(txl_FullMailBody__c = mail.plainTextBody?.left(131072));
 
         return new Messaging.InboundEmailResult();
     }


### PR DESCRIPTION
Some flow error emails are really, really long. Those emails result in an error when processed:

> The apex class ErrorMailReceiver failed due to: System.DmlException: Insert failed. First exception on row 0; first error: STRING_TOO_LONG, Full Mail Body: data value too large: Debug the failed interview in Flow Builder for the interview GUID ...
Class.ErrorMailReceiver.handleInboundEmail: line 4, column 1

 Adding `?.left(131072)` solves this issue.