### PR TITLE
Remove hardcoded users

### DIFF
--- a/DASHBOARD.md
+++ b/DASHBOARD.md
@@ -1,0 +1,12 @@
+## A Note About Dashboard Configuration
+
+We recommend that you manually set a Specified User for the dashboard after deployment.  The out-of-the-box dashboard may appear differently to different users depending on their permissions and sharing.
+
+**Background**: In order to allow this unlocked package to be manually installed using SFDX-based tools (such as the "Deploy to Salesforce" button on the main README), it was neccessary to remove any hard-coded references to specific users who may not be present in your Salesforce org or sandbox.  As a result, the "View Dashboard As" setting is configured to "The Dashboard Viewer", as opposed to a specified user with full visibility into all records.
+
+To solve this issue, after deployment:
+
+1) Ensure your own user has the Permission Set "Org Error Inbox Admin" and is a member of the Public Group "Org Error Inbox Admin"
+2) Navigate to the Dashboard App, and select "edit" for the "Org Error Inbox" dashboard
+3) Click the "Settings" gear icon in the upper-right of the dashboard editor, and you will find the setting "View Dashboard As" where you can select "Me", "Other User", or "The Dashboard Viewer" (the latter being the deployment default for this dashboard).
+4) Typically, it is recommended to select "Other User", and select a service account or integration user with full visibility into all OrgError__c records.  This will ensure the dashboard appears consistently to all users who view it in your org or sandbox.

--- a/README.md
+++ b/README.md
@@ -33,11 +33,16 @@ Deploy as source or install as Unlocked Package to your Production or Sandbox or
 
 ## Note About Dashboard Configuration
 
-In order to allow this unlocked package to be manually installed using SFDX-based tools (such as the "Deploy to Salesforce" button above), it was neccessary to remove any hard-coded references to specific users who may not be present in your Salesforce org or sandbox.  As a result, the "View Dashboard As" setting is configured to "The Dashboard Viewer", as opposed to a specified user with full visibility into all records.  This may cause the dashboard to appear differently depending on which user is viewing it.
+It is recommended that you manually set a Specified User for the dashboard after deployment.  The out-of-the-box dashboard may appear differently to different users depending on their permissions and sharing.
 
-It is recommended that you manually set a Specified User for the dashboard after deployment.  First, ensure your own user has the Permission Set "Org Error Inbox Admin" and is a member of the Public Group "Org Error Inbox Admin".  Then, navigate to the Dashboard App, and select "edit" for the Org Error Inbox dashboard.  Click the "Settings" gear icon in the upper-right of the dashboard editor, and you will find the setting "View Dashboard As" where you can select "Me", "Other User", or "The Dashboard Viewer" (the latter being the deployment default for this dashboard).
+**Background**: In order to allow this unlocked package to be manually installed using SFDX-based tools (such as the "Deploy to Salesforce" button above), it was neccessary to remove any hard-coded references to specific users who may not be present in your Salesforce org or sandbox.  As a result, the "View Dashboard As" setting is configured to "The Dashboard Viewer", as opposed to a specified user with full visibility into all records.
 
-Typically, it is recommended to select "Other User", and select a service account or integration user with full visibility into all OrgError__c records.  This will ensure the dashboard appears consistently to all users who view it in your org or sandbox.
+To solve this issue, after deployment:
+
+1) Ensure your own user has the Permission Set "Org Error Inbox Admin" and is a member of the Public Group "Org Error Inbox Admin"
+2) Navigate to the Dashboard App, and select "edit" for the "Org Error Inbox" dashboard
+3) Click the "Settings" gear icon in the upper-right of the dashboard editor, and you will find the setting "View Dashboard As" where you can select "Me", "Other User", or "The Dashboard Viewer" (the latter being the deployment default for this dashboard).
+4) Typically, it is recommended to select "Other User", and select a service account or integration user with full visibility into all OrgError__c records.  This will ensure the dashboard appears consistently to all users who view it in your org or sandbox.
 
 
 ## How can I contribute and extend it?

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ Deploy as source or install as Unlocked Package to your Production or Sandbox or
 
 [Install Unlocked Package (Sandbox)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tVI0000002n6HYAQ)
 
-<a href="DASHBOARD.md">A note about recommended dashboard configuration</a>
+### Notes ###
+
+[Recommended dashboard configuration](DASHBOARD.md)
 
 ## How can I contribute and extend it?
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Salesforce Orgs can send out notification emails when unhandled exceptions happen in Apex code or Flow or elsewhere. Admins can [define an email adress for this](https://help.salesforce.com/s/articleView?id=000385876&type=1) in the setup. The Org Error Inbox is a native Salesforce App that provides you with an email address to receive those emails. Error emails are parsed and stored in a Custom Object where you can report on and create sophisticated Support workflows.
 
+
 **Features:**
 
 - **Custom Metadata** Tokenizer for flexible Email Parsing
@@ -30,6 +31,14 @@ Deploy as source or install as Unlocked Package to your Production or Sandbox or
 [Install Unlocked Package (Production)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tVI0000002n6HYAQ)
 
 [Install Unlocked Package (Sandbox)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tVI0000002n6HYAQ)
+
+## Note About Dashboard Configuration
+
+In order to allow this unlocked package to be manually installed using SFDX-based tools (such as the "Deploy to Salesforce" button above), it was neccessary to remove any hard-coded references to specific users who may not be present in your Salesforce org or sandbox.  As a result, the "View Dashboard As" setting is configured to "The Dashboard Viewer", as opposed to a specified user with full visibility into all records.  This may cause the dashboard to appear differently depending on which user is viewing it.
+
+It is recommended that you manually set a Specified User for the dashboard after deployment.  First, ensure your own user has the Permission Set "Org Error Inbox Admin" and is a member of the Public Group "Org Error Inbox Admin".  Then, navigate to the Dashboard App, and select "edit" for the Org Error Inbox dashboard.  Click the "Settings" gear icon in the upper-right of the dashboard editor, and you will find the setting "View Dashboard As" where you can select "Me", "Other User", or "The Dashboard Viewer" (the latter being the deployment default for this dashboard).
+
+Typically, it is recommended to select "Other User", and select a service account or integration user with full visibility into all OrgError__c records.  This will ensure the dashboard appears consistently to all users who view it in your org or sandbox.
 
 
 ## How can I contribute and extend it?

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Deploy as source or install as Unlocked Package to your Production or Sandbox or
 
 [Recommended dashboard configuration](DASHBOARD.md)
 
+For government and highly-regulated industries, where AI usage may be restricted or disallowed, see [this fork of Org Error Inbox](https://github.com/billyJoePiano/org-error-inbox/).  All OpenAI integrations have been removed, but it otherwise retains core functionality.
+
 ## How can I contribute and extend it?
 
 The project was built as a flexible unnamespaced SFDX project. The repo contains all the scripts to automatically build dev scratch orgs and sample data to play with.

--- a/README.md
+++ b/README.md
@@ -31,19 +31,7 @@ Deploy as source or install as Unlocked Package to your Production or Sandbox or
 
 [Install Unlocked Package (Sandbox)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tVI0000002n6HYAQ)
 
-## Note About Dashboard Configuration
-
-It is recommended that you manually set a Specified User for the dashboard after deployment.  The out-of-the-box dashboard may appear differently to different users depending on their permissions and sharing.
-
-**Background**: In order to allow this unlocked package to be manually installed using SFDX-based tools (such as the "Deploy to Salesforce" button above), it was neccessary to remove any hard-coded references to specific users who may not be present in your Salesforce org or sandbox.  As a result, the "View Dashboard As" setting is configured to "The Dashboard Viewer", as opposed to a specified user with full visibility into all records.
-
-To solve this issue, after deployment:
-
-1) Ensure your own user has the Permission Set "Org Error Inbox Admin" and is a member of the Public Group "Org Error Inbox Admin"
-2) Navigate to the Dashboard App, and select "edit" for the "Org Error Inbox" dashboard
-3) Click the "Settings" gear icon in the upper-right of the dashboard editor, and you will find the setting "View Dashboard As" where you can select "Me", "Other User", or "The Dashboard Viewer" (the latter being the deployment default for this dashboard).
-4) Typically, it is recommended to select "Other User", and select a service account or integration user with full visibility into all OrgError__c records.  This will ensure the dashboard appears consistently to all users who view it in your org or sandbox.
-
+<a href="DASHBOARD.md">A note about recommended dashboard configuration</a>
 
 ## How can I contribute and extend it?
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 Salesforce Orgs can send out notification emails when unhandled exceptions happen in Apex code or Flow or elsewhere. Admins can [define an email adress for this](https://help.salesforce.com/s/articleView?id=000385876&type=1) in the setup. The Org Error Inbox is a native Salesforce App that provides you with an email address to receive those emails. Error emails are parsed and stored in a Custom Object where you can report on and create sophisticated Support workflows.
 
-
 **Features:**
 
 - **Custom Metadata** Tokenizer for flexible Email Parsing

--- a/force-app/main/default/dashboards/OrgErrorDashboards.dashboardFolder-meta.xml
+++ b/force-app/main/default/dashboards/OrgErrorDashboards.dashboardFolder-meta.xml
@@ -2,8 +2,8 @@
 <DashboardFolder xmlns="http://soap.sforce.com/2006/04/metadata">
     <folderShares>
         <accessLevel>Manage</accessLevel>
-        <sharedTo>dmitry@inbox.scratch</sharedTo>
-        <sharedToType>User</sharedToType>
+        <sharedTo>Org_Error_Inbox_Admin</sharedTo>
+        <sharedToType>Group</sharedToType>
     </folderShares>
     <name>Org Error Dashboards</name>
 </DashboardFolder>

--- a/force-app/main/default/dashboards/OrgErrorDashboards/fwmGhWlBjfYfeXUhDkYuWoSIqRkTtC.dashboard-meta.xml
+++ b/force-app/main/default/dashboards/OrgErrorDashboards/fwmGhWlBjfYfeXUhDkYuWoSIqRkTtC.dashboard-meta.xml
@@ -311,10 +311,8 @@
         <numberOfColumns>12</numberOfColumns>
         <rowHeight>36</rowHeight>
     </dashboardGridLayout>
-    <dashboardType>SpecifiedUser</dashboardType>
+    <dashboardType>LoggedInUser</dashboardType>
     <isGridLayout>true</isGridLayout>
-    <owner>dmitry@inbox.scratch</owner>
-    <runningUser>dmitry@inbox.scratch</runningUser>
     <textColor>#000000</textColor>
     <title>Org Errors Overview</title>
     <titleColor>#000000</titleColor>

--- a/force-app/main/default/groups/Org_Error_Inbox_Admin.group-meta.xml
+++ b/force-app/main/default/groups/Org_Error_Inbox_Admin.group-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Group xmlns="http://soap.sforce.com/2006/04/metadata">
+    <doesIncludeBosses>false</doesIncludeBosses>
+    <name>Org Error Inbox Admin</name>
+</Group>

--- a/force-app/main/default/reports/OrgErrorReports.reportFolder-meta.xml
+++ b/force-app/main/default/reports/OrgErrorReports.reportFolder-meta.xml
@@ -2,8 +2,8 @@
 <ReportFolder xmlns="http://soap.sforce.com/2006/04/metadata">
     <folderShares>
         <accessLevel>Manage</accessLevel>
-        <sharedTo>dmitry@inbox.scratch</sharedTo>
-        <sharedToType>User</sharedToType>
+        <sharedTo>Org_Error_Inbox_Admin</sharedTo>
+        <sharedToType>Group</sharedToType>
     </folderShares>
     <name>Org Error Reports</name>
 </ReportFolder>


### PR DESCRIPTION
This PR removes the hardcoded user `dimitry@inbox.scratch`, which tends to trigger errors when trying to manually deploy the unlocked package using SFDX-based tools, such as the "Deploy to Salesforce" button in the README frontpage.

I replaced this hardcoded user with a new public group "Org Error Inbox Admin".  The new Public Group is used for the `<sharedTo>` tag in "OrgErrorDashboards" (dashboardFolder metadata) and "OrgErrorReports" (reportsFolder metadata).

For the dashboard, the `<dashboardType>` had to be changed from "SpecifiedUser" to "LoggedInUser", since it is not possible to have a SpecifiedUser who is dynamically determined at the time of deployment.  This change may impact the way the dashboard appears out-of-the-box based on the viewing user's permissions.  However, the README now includes a link to DASHBOARD.md which instructs installers to manually change this configuration themselves after deployment, to set a specified user for the dashboard.